### PR TITLE
Psych Ward - prevent sacrifice menu crash, fix missing package

### DIFF
--- a/psych_ward/scripts/mods/psych_ward/psych_ward.lua
+++ b/psych_ward/scripts/mods/psych_ward/psych_ward.lua
@@ -588,3 +588,22 @@ end)
 mod:hook_safe(CLASS.MissionBoardView, "on_enter", function(self)
   self._regions_latency = self._regions_latency or {}
 end)
+
+-- prevent issues with sacrifice menu
+local sacrifice_package_id = nil
+
+mod:hook(CLASS.CraftingMechanicusBarterItemsView, "_setup_background_world", function(func, self)
+  local game_mode_name = Managers.state.game_mode and Managers.state.game_mode:game_mode_name()
+  if game_mode_name ~= "hub" then
+    sacrifice_package_id = not sacrifice_package_id and Managers.package:load("packages/ui/views/masteries_overview_view/masteries_overview_view", mod.name, nil, true)
+    return -- running func causes a crash; there's presumably something else that isn't loaded, but this func is not needed
+  end
+  func(self)
+end)
+
+mod:hook_safe(CLASS.CraftingView, "on_exit", function(self)
+  if sacrifice_package_id then
+    Managers.package:release(sacrifice_package_id)
+    sacrifice_package_id = nil
+  end
+end)

--- a/psych_ward/scripts/mods/psych_ward/psych_ward.lua
+++ b/psych_ward/scripts/mods/psych_ward/psych_ward.lua
@@ -595,7 +595,7 @@ local sacrifice_package_id = nil
 mod:hook(CLASS.CraftingMechanicusBarterItemsView, "_setup_background_world", function(func, self)
   local game_mode_name = Managers.state.game_mode and Managers.state.game_mode:game_mode_name()
   if game_mode_name ~= "hub" then
-    sacrifice_package_id = not sacrifice_package_id and Managers.package:load("packages/ui/views/masteries_overview_view/masteries_overview_view", mod.name, nil, true)
+    sacrifice_package_id = sacrifice_package_id or Managers.package:load("packages/ui/views/masteries_overview_view/masteries_overview_view", mod.name, nil, true)
     return -- running func causes a crash; there's presumably something else that isn't loaded, but this func is not needed
   end
   func(self)


### PR DESCRIPTION
A quick fix for the sacrifice menu crashing the game and missing a package. I had to do this for GoToMastery, so I figured I might as well offer the same fix here.