### PR TITLE
Fix "Nightmares and Visions" issues

### DIFF
--- a/crosshair_hud/scripts/mods/crosshair_hud/hud_element_crosshair_hud/features/ally.lua
+++ b/crosshair_hud/scripts/mods/crosshair_hud/hud_element_crosshair_hud/features/ally.lua
@@ -630,7 +630,8 @@ local function update_status(parent, dt, t, widget, player)
     return
   end
 
-  local string_symbol = profile.archetype.string_symbol
+  local archetype_name = profile.archetype and profile.archetype.name
+  local string_symbol = archetype_name and UISettings.archetype_font_icon_simple[archetype_name] or "•"
   local player_name = player:name()
   local is_alive = unit_alive(player.player_unit)
 

--- a/crosshair_hud/scripts/mods/crosshair_hud/hud_element_crosshair_hud/features/templates/coherency/archetype.lua
+++ b/crosshair_hud/scripts/mods/crosshair_hud/hud_element_crosshair_hud/features/templates/coherency/archetype.lua
@@ -192,7 +192,8 @@ function template.update(parent, dt, t)
       end
 
       local style = widget_style[id]
-      local text = profile.archetype.string_symbol or "•••"
+      local archetype_name = profile.archetype and profile.archetype.name
+      local text = archetype_name and UISettings.archetype_font_icon_simple[archetype_name] or "•"
       widget_content[id] = text
 
       style.text_color = color


### PR DESCRIPTION
The game update has apparently removed `string_symbol` from the `archetype` table. This caused the symbols to not show correctly for coherency and to crash when using the ally indicators (as the text widget was trying to render `nil`). I changed it to look up the archetype icons from `UISettings` and to use `"•"` as a fallback to minimize the impact if the archetype icons are relocated again in a future update.