### PR TITLE
fix(crosshair_hud): add missing ability buffs, fix duration calculation

### DIFF
--- a/crosshair_hud/scripts/mods/crosshair_hud/hud_element_crosshair_hud/features/ability.lua
+++ b/crosshair_hud/scripts/mods/crosshair_hud/hud_element_crosshair_hud/features/ability.lua
@@ -226,15 +226,19 @@ local function _get_ability_buff_duration(player_unit)
   local ability_stance_buffs = {
     psyker_overcharge_stance_infinite_casting = true,
     veteran_combat_ability_stance_master = true,
+    veteran_combat_ability_stance_master_increased_duration = true,
     veteran_invisibility = true,
     zealot_invisibility = true,
     zealot_invisibility_increased_duration = true,
     ogryn_ranged_stance = true,
+    adamant_hunt_stance = true,
     broker_focus_stance = true,
     broker_focus_stance_improved = true,
     broker_punk_rage_stance = true,
   }
   
+  local t = Managers.time:time("gameplay")
+
   for _, buff in pairs(buff_ext._buffs_by_index) do
     if buff then
       local template = buff:template()
@@ -242,17 +246,16 @@ local function _get_ability_buff_duration(player_unit)
       if not buff_name then
         buff_name = buff.template_name and buff:template_name()
       end
-      
+
       if buff_name and ability_stance_buffs[buff_name] then
-        local get_duration = buff.duration
-        local get_progress = buff.duration_progress
+        local max_dur = buff:duration()
         
-        if get_duration and type(get_duration) == "function" and 
-           get_progress and type(get_progress) == "function" then
-          local max_dur = get_duration(buff)
-          if max_dur and max_dur > 0 then
-            local progress = get_progress(buff) or 0
-            local remaining = max_dur * progress
+        if max_dur and max_dur > 0 then
+          local start_time = buff:start_time()
+
+          if start_time then
+            local remaining = math.max(max_dur - (t - start_time), 0)
+
             if remaining > longest_remaining then
               longest_remaining = remaining
               longest_max = max_dur


### PR DESCRIPTION
- Add missing ability buffs to the ability_stance_buffs table:
  - veteran_combat_ability_stance_master_increased_duration
  - adamant_hunt_stance
- Fix duration calculation so it properly calculates
  remaining time for buffs that extend their duration

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>
